### PR TITLE
Fix typo and code quality issues

### DIFF
--- a/editor/main_window.py
+++ b/editor/main_window.py
@@ -196,8 +196,6 @@ class MainWindow(QMainWindow):
         # Tooltips
         self.camera_movement_learned = self.config.getboolean('Tooltips', 'camera_movement_learned', fallback=False)
         self.startup_tooltip_shown = False
-        self.camera_movement_learned = self.config.getboolean('Tooltips', 'camera_movement_learned', fallback=False)
-        self.startup_tooltip_shown = False
         self.tooltip_tips = [
             "Right-click + WASD: Move camera",
             "Mouse wheel: Zoom in/out",

--- a/engine/player.py
+++ b/engine/player.py
@@ -91,13 +91,11 @@ class Player:
         
         if self._check_overlap(colliders, ignore_brush=self.ground_object):
             # Try Step Up
-            self.pos.x = original_pos.x 
-            self.pos.y += self.step_height 
-            self.pos.x += self.velocity.x * delta 
-            
-            if not self._check_overlap(colliders, ignore_brush=self.ground_object):
-                pass 
-            else:
+            self.pos.x = original_pos.x
+            self.pos.y += self.step_height
+            self.pos.x += self.velocity.x * delta
+
+            if self._check_overlap(colliders, ignore_brush=self.ground_object):
                 self.pos = original_pos
                 self.pos.x += self.velocity.x * delta
                 # IMPORTANT: Pass ground_object to ignore it during X resolution
@@ -109,13 +107,11 @@ class Player:
         
         if self._check_overlap(colliders, ignore_brush=self.ground_object):
             # Try Step Up
-            self.pos.z = original_pos.z 
-            self.pos.y += self.step_height 
-            self.pos.z += self.velocity.z * delta 
-            
-            if not self._check_overlap(colliders, ignore_brush=self.ground_object):
-                pass
-            else:
+            self.pos.z = original_pos.z
+            self.pos.y += self.step_height
+            self.pos.z += self.velocity.z * delta
+
+            if self._check_overlap(colliders, ignore_brush=self.ground_object):
                 self.pos = original_pos
                 self.pos.z += self.velocity.z * delta
                 # IMPORTANT: Pass ground_object to ignore it during Z resolution

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from editor.main_window import MainWindow
 
 def clean_pycache():
     """
-    Depreceted 
+    Deprecated
     """
     pass
 


### PR DESCRIPTION
## Summary
This PR fixes several minor code quality issues found in the codebase:

### Changes
1. **main.py**: Fixed typo "Depreceted" → "Deprecated" in the `clean_pycache()` function docstring
2. **editor/main_window.py**: Removed duplicate variable assignments (`camera_movement_learned` and `startup_tooltip_shown` were assigned twice on consecutive lines)
3. **engine/player.py**: Simplified step-up collision logic by removing unnecessary empty if blocks with `pass` statements

## Impact
- No functional changes
- Improves code readability and maintainability
- Removes redundant code

## Test Plan
- Existing functionality should be unaffected
- Code is functionally equivalent (the player collision logic behavior is unchanged)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>